### PR TITLE
Import second release (consolidated version 2012 - August 2011)

### DIFF
--- a/schemas/SDMXMessage.xsd
+++ b/schemas/SDMXMessage.xsd
@@ -35,7 +35,7 @@
 
   <xs:element name="Structure" type="StructureType">
     <xs:annotation>
-      <xs:documentation>Structure is a message that contains structural metadata. It may contain any of the following; categorisations, category schemes, code lists, concepts (concept schemes and stand-alone concepts), constraints (attachment and content) data flows, hierarchical code lists, metadata flows, metadata structure definitions, organisation schemes, processes, reporting taxonomies, and structure sets.</xs:documentation>
+      <xs:documentation>Structure is a message that contains structural metadata. It may contain any of the following; categorisations, category schemes, code lists, concepts (concept schemes), constraints (attachment and content) data flows, hierarchical code lists, metadata flows, metadata structure definitions, organisation schemes, processes, reporting taxonomies, and structure sets.</xs:documentation>
     </xs:annotation>
   </xs:element>
 

--- a/schemas/SDMXStructure.xsd
+++ b/schemas/SDMXStructure.xsd
@@ -131,7 +131,7 @@
       </xs:element>
       <xs:element name="Concepts" type="ConceptsType" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Concepts contains a collection of concept descriptions. The concepts described may be both stand-alone concepts and concepts contained within schemes. The concepts may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
+          <xs:documentation>Concepts contains a collection of concept descriptions. The concepts described are contained within schemes. The concepts may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
         </xs:annotation>
         <xs:unique name="UniqueConceptScheme">
           <xs:selector xpath="structure:ConceptScheme"/>
@@ -366,7 +366,7 @@
 
   <xs:complexType name="ConceptsType">
     <xs:annotation>
-      <xs:documentation>ConceptsType describes the structure of the concepts container. It contains one or more stand-alone concept or concept scheme, which can be explicitly detailed or referenced from an external structure document or registry service. This container may contain a mix of both stand-alone concepts and concept schemes.</xs:documentation>
+      <xs:documentation>ConceptsType describes the structure of the concepts container. It contains one or more stand-alone concept or concept scheme, which can be explicitly detailed or referenced from an external structure document or registry service.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="ConceptScheme" type="ConceptSchemeType" minOccurs="0" maxOccurs="unbounded">

--- a/schemas/SDMXStructureConcept.xsd
+++ b/schemas/SDMXStructureConcept.xsd
@@ -6,7 +6,7 @@
 
   <xs:annotation>
     <xs:appinfo>SDMX Concept Structure Module</xs:appinfo>
-    <xs:documentation>The concept structure module defines the structure of concept scheme, concept, and stand-alone concept constructs.</xs:documentation>
+    <xs:documentation>The concept structure module defines the structure of concept scheme and concept constructs.</xs:documentation>
   </xs:annotation>
 
   <xs:complexType name="ConceptSchemeType">

--- a/schemas/SDMXStructureStructureSet.xsd
+++ b/schemas/SDMXStructureStructureSet.xsd
@@ -450,7 +450,7 @@
               <xs:documentation>Target provides a reference to a structure (data or metadata) or a structure usage (dataflow or metadataflow) to which components from the source are to mapped.</xs:documentation>
             </xs:annotation>
           </xs:element>
-          <xs:element name="ComponentMap" type="ComponentMapType">
+          <xs:element name="ComponentMap" type="ComponentMapType" maxOccurs="unbounded">
             <xs:annotation>
               <xs:documentation>ComponentMap defines the relationship between the components of the source and target structures, including information on how the value from the source component relates to values in the target component.</xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
Here are the original release notes:

2011-07-14: BUG FIXES
			
SDMXMessage.xsd: Documentation of Structure updated to remove references to stand-alone concepts.

SDMXStructure.xsd: Documentation of StructureType/Concepts and ConceptTypes updated to remove references to stand-alone concepts.

SDMXStructureConcept.xsd: documentation of schema file updated to remove references to stand-alone concepts.

SDMXStructureStructureSet.xsd: StructureMapType/ComponentMap maxOccurs changed from default (1) to unbounded.