### PR TITLE
Cr-25 Changes on the XSDs for versioning defaults in SOAP Query

### DIFF
--- a/schemas/SDMXCommon.xsd
+++ b/schemas/SDMXCommon.xsd
@@ -501,19 +501,6 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="WildCardValueType">
-    <xs:annotation>
-      <xs:documentation>WildCardValueType is a single value code list, used to include the '%' character - indicating that an entire field is wild carded.</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="%">
-        <xs:annotation>
-          <xs:documentation>Indicates a wild card value.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-    </xs:restriction>
-  </xs:simpleType>
-
   <xs:complexType name="QueryableDataSourceType">
     <xs:annotation>
       <xs:documentation>QueryableDataSourceType describes a data source which is accepts an standard SDMX Query message and responds appropriately.</xs:documentation>

--- a/schemas/SDMXCommon.xsd
+++ b/schemas/SDMXCommon.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2010 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" elementFormDefault="qualified" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.1_20130301">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" elementFormDefault="qualified" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.1_20180323">
   <xs:include schemaLocation="SDMXCommonReferences.xsd"/>
   <!-- Note: The following import statement sometimes causes problems with IE 6.* If you have this problem, comment it out. -->
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>

--- a/schemas/SDMXCommonReferences.xsd
+++ b/schemas/SDMXCommonReferences.xsd
@@ -77,7 +77,7 @@
     <xs:annotation>
       <xs:documentation>VersionQueryType combines the VersionType and LateBoundVersionType to allow one to query for either a specific version of an object, or the latest version by specifying the '*' value.</xs:documentation>
     </xs:annotation>
-    <xs:union memberTypes="VersionType LateBoundVersionType"/>
+    <xs:union memberTypes="VersionType LateBoundVersionType WildCardValueType"/>
   </xs:simpleType>
 
   <xs:simpleType name="LateBoundVersionType">

--- a/schemas/SDMXCommonReferences.xsd
+++ b/schemas/SDMXCommonReferences.xsd
@@ -80,6 +80,19 @@
     <xs:union memberTypes="VersionType LateBoundVersionType WildCardValueType"/>
   </xs:simpleType>
 
+	<xs:simpleType name="WildCardValueType">
+		<xs:annotation>
+			<xs:documentation>WildCardValueType is a single value code list, used to include the '%' character - indicating that an entire field is wild carded.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="%">
+				<xs:annotation>
+					<xs:documentation>Indicates a wild card value.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+  
   <xs:simpleType name="LateBoundVersionType">
     <xs:annotation>
       <xs:documentation>LateBoundVersionType is a single value code list, used to include the '*' character - indicating that the latest version of an object is required.</xs:documentation>

--- a/schemas/SDMXCommonReferences.xsd
+++ b/schemas/SDMXCommonReferences.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2010 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" version="2.1_20130301">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" version="2.1_20180323">
 
 
   <xs:annotation>

--- a/schemas/SDMXRegistryBase.xsd
+++ b/schemas/SDMXRegistryBase.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2010 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" version="2.1_20180323">
   <xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" schemaLocation="SDMXCommon.xsd"/>
 
   <xs:annotation>

--- a/schemas/SDMXRegistryBase.xsd
+++ b/schemas/SDMXRegistryBase.xsd
@@ -132,13 +132,6 @@
     <xs:union memberTypes="common:NestedIDType common:WildCardValueType"/>
   </xs:simpleType>
 
-  <xs:simpleType name="VersionQueryType">
-    <xs:annotation>
-      <xs:documentation>VersionQueryType is a simple type that allows for a version number to be substituted with a wild card character ("%") or a late bound character ("*").</xs:documentation>
-    </xs:annotation>
-    <xs:union memberTypes="common:VersionQueryType common:WildCardValueType"/>
-  </xs:simpleType>
-
   <xs:complexType name="IdentifiableQueryType">
     <xs:annotation>
       <xs:documentation>IdentifiableQueryType describes the structure of a query for an identifiable object.</xs:documentation>
@@ -156,7 +149,7 @@
     </xs:annotation>
     <xs:complexContent>
       <xs:extension base="IdentifiableQueryType">
-        <xs:attribute name="version" type="VersionQueryType" default="*">
+        <xs:attribute name="version" type="common:VersionQueryType" default="*">
           <xs:annotation>
             <xs:documentation>The version attribute is used to query for an object based on its version. This can be and explicit value, wild-carded ("%"), or late-bound ("*"). A wild carded version will match any version of the object where as a late-bound version will only match the latest version.</xs:documentation>
           </xs:annotation>

--- a/schemas/SDMXRegistrySubscription.xsd
+++ b/schemas/SDMXRegistrySubscription.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2010 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" version="2.1_20180323">
   <xs:include schemaLocation="SDMXRegistryBase.xsd"/>
   <xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" schemaLocation="SDMXCommon.xsd"/>
   <xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" schemaLocation="SDMXStructure.xsd"/>

--- a/schemas/SDMXRegistrySubscription.xsd
+++ b/schemas/SDMXRegistrySubscription.xsd
@@ -422,7 +422,7 @@
             <xs:documentation>ID subscribes to the events of the specific instance of the object type where the value provided here matches the id of the object and the value provided in the version field matches the version of the object. The default value is the wildcard character("%").</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="Version" type="VersionQueryType" default="%">
+        <xs:element name="Version" type="common:VersionQueryType" default="%">
           <xs:annotation>
             <xs:documentation>Version subscribes to the events of the specific instance of the object type where the value provided in the id field matches the id of the object and the value here matches the version of the object. The default value is the wildcard character("%"). Note that in addition to being wild-carded, this can also be bound to the latest version of the object with the late-bound character("*").</xs:documentation>
           </xs:annotation>


### PR DESCRIPTION
Four XSDs have been changed to fix the missing '%' character, denoting the 'all' keyword for versions.
Issue #25 